### PR TITLE
Quote parameter name for parsing errors

### DIFF
--- a/Remora.Commands/Results/ParameterParsingError.cs
+++ b/Remora.Commands/Results/ParameterParsingError.cs
@@ -32,4 +32,4 @@ namespace Remora.Commands.Results;
 /// <param name="Parameter">The parameter that failed to parse.</param>
 [PublicAPI]
 public record ParameterParsingError(BoundParameterShape Parameter) :
-    ResultError($"Failed to parse the value of '{Parameter.ParameterShape.HintName}'.");
+    ResultError($"Failed to parse the value of \"{Parameter.ParameterShape.HintName}\".");

--- a/Remora.Commands/Results/ParameterParsingError.cs
+++ b/Remora.Commands/Results/ParameterParsingError.cs
@@ -32,4 +32,4 @@ namespace Remora.Commands.Results;
 /// <param name="Parameter">The parameter that failed to parse.</param>
 [PublicAPI]
 public record ParameterParsingError(BoundParameterShape Parameter) :
-    ResultError($"Failed to parse the value of {Parameter.ParameterShape.HintName}.");
+    ResultError($"Failed to parse the value of '{Parameter.ParameterShape.HintName}'.");


### PR DESCRIPTION
Makes error message consistent with other errors present in various Remora repos, wherein parameters (to the error) are quoted.