### PR TITLE
fix(parser): Make DateTimeOffsetParser use UTC by default

### DIFF
--- a/Remora.Commands/Parsers/Builtin/DateTimeOffsetParser.cs
+++ b/Remora.Commands/Parsers/Builtin/DateTimeOffsetParser.cs
@@ -41,7 +41,7 @@ public class DateTimeOffsetParser : AbstractTypeParser<DateTimeOffset>
     {
         return new ValueTask<Result<DateTimeOffset>>
         (
-            !DateTimeOffset.TryParse(value, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None, out var result)
+            !DateTimeOffset.TryParse(value, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal, out var result)
                 ? new ParsingError<DateTimeOffset>(value)
                 : result
         );


### PR DESCRIPTION
Previously, parsing a DateTimeOffset would use the machine's local timezone, however for consistency, UTC should probably be preferred 